### PR TITLE
feat: crontab 관련 학습 자동화

### DIFF
--- a/Docker-compose.yml
+++ b/Docker-compose.yml
@@ -9,3 +9,17 @@ services:
     volumes:
       - ./mlruns:/app/mlruns
     restart: unless-stopped
+
+  trainer:
+    build:
+      context: .
+      dockerfile: auto_run/Dockerfile
+    container_name: mlflow-trainer
+    depends_on:
+      - mlflow
+    environment:
+      MLFLOW_TRACKING_URI: "http://mlflow:5000"
+    volumes:
+      - .:/app
+      - ./logs:/app/logs
+    restart: unless-stopped

--- a/auto_run/Dockerfile
+++ b/auto_run/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3 python3-pip cron bash && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN pip3 install --upgrade pip && \
+    pip3 install uv && \
+    uv sync
+
+COPY src/             /app/src/
+COPY main.py          /app/
+COPY src/train_model.py /app/src/train_model.py
+COPY auto_run/run_training.sh /app/auto_run/run_training.sh
+COPY auto_run/crontab.txt /etc/cron.d/ml_training
+
+RUN chmod +x /app/auto_run/run_training.sh && \
+    chmod 644 /etc/cron.d/ml_training && \
+    crontab /etc/cron.d/ml_training && \
+    mkdir -p /app/logs
+
+CMD ["cron", "-f"]

--- a/auto_run/crontab.txt
+++ b/auto_run/crontab.txt
@@ -1,0 +1,6 @@
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# MLflow 서버 주소를 cron 환경변수에 추가
+MLFLOW_TRACKING_URI=http://mlflow:5000
+# 분 시  일 월 요일 사용자 명령
+0 0 * * * root /app/auto_run/run_training.sh

--- a/auto_run/requirements.txt
+++ b/auto_run/requirements.txt
@@ -1,7 +1,0 @@
-numpy==1.25.1
-pandas==2.1.0
-torch==2.1.0
-torchvision==0.16.0
-scikit-learn==1.3.0
-matplotlib==3.8.0
-mlflow==2.8.0

--- a/auto_run/requirements.txt
+++ b/auto_run/requirements.txt
@@ -1,0 +1,7 @@
+numpy==1.25.1
+pandas==2.1.0
+torch==2.1.0
+torchvision==0.16.0
+scikit-learn==1.3.0
+matplotlib==3.8.0
+mlflow==2.8.0

--- a/auto_run/run_training.sh
+++ b/auto_run/run_training.sh
@@ -1,0 +1,16 @@
+# 1) 스크립트 위치 (auto_run)로 이동
+cd "$(dirname "$0")"
+# 2) 한 단계 위(/app)로 이동
+cd ..
+
+# 3) 로그 디렉터리 생성
+mkdir -p logs
+
+# 4) uv run 명령을 실행할 때 환경변수를 한 줄에 함께 지정
+TIMESTAMP=$(date '+%Y%m%d_%H%M%S')
+MLFLOW_TRACKING_URI=http://mlflow:5000 \
+  uv run python src/train_model.py \
+  > "logs/train_${TIMESTAMP}.log" 2>&1
+
+# 5) 완료 메시지
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] uv run python src/train_model.py 완료 → logs/train_${TIMESTAMP}.log"

--- a/auto_run/run_training.sh
+++ b/auto_run/run_training.sh
@@ -8,8 +8,7 @@ mkdir -p logs
 
 # 4) uv run 명령을 실행할 때 환경변수를 한 줄에 함께 지정
 TIMESTAMP=$(date '+%Y%m%d_%H%M%S')
-MLFLOW_TRACKING_URI=http://mlflow:5000 \
-  uv run python src/train_model.py \
+uv run python src/train_model.py \
   > "logs/train_${TIMESTAMP}.log" 2>&1
 
 # 5) 완료 메시지

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -9,7 +9,7 @@ from sklearn.metrics import precision_score, recall_score, f1_score
 from data_loader import get_dataloaders
 from eval import evaluate
 from models import HybridCNN
-
+mlflow.set_tracking_uri("http://mlflow:5000")
 def set_seed(seed=42):
     random.seed(seed)
     np.random.seed(seed)
@@ -30,7 +30,7 @@ def train(num_epochs=20, learning_rate=0.001, batch_size=64, seed=42):
 
     set_seed(seed)
     
-    mlflow.set_tracking_uri("http://localhost:5000")
+    mlflow.set_tracking_uri("http://mlflow:5000")
     mlflow.set_experiment("mnist-digit-captcha")    
     with mlflow.start_run():    
         device = get_device()
@@ -81,11 +81,10 @@ def train(num_epochs=20, learning_rate=0.001, batch_size=64, seed=42):
             mlflow.log_metric("recall", recall, step=epoch)
             mlflow.log_metric("f1_score", f1, step=epoch)   
             if val_acc > best_accuracy:
-                best_accuracy = val_acc
-                torch.save(model.state_dict(), "../tests/best_model.pth")
-                mlflow.log_artifact("../tests/best_model.pth")
-                print(f"Best model saved and logged with val acc: {val_acc:.4f}")   
-            scheduler.step()    
+                torch.save(model.state_dict(), "tests/best_model.pth")
+                mlflow.log_artifact("tests/best_model.pth")
+                print(f"Best model saved and logged with val acc: {val_acc:.4f}")
+            scheduler.step()
         mlflow.pytorch.log_model(model, artifact_path="model", registered_model_name="HybridCNN")
         mlflow.log_param("epochs", num_epochs)
         mlflow.log_param("optimizer", "Adam")

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -9,7 +9,8 @@ from sklearn.metrics import precision_score, recall_score, f1_score
 from data_loader import get_dataloaders
 from eval import evaluate
 from models import HybridCNN
-mlflow.set_tracking_uri("http://mlflow:5000")
+from mlflow.tracking import MlflowClient
+from datetime import datetime
 def set_seed(seed=42):
     random.seed(seed)
     np.random.seed(seed)
@@ -27,10 +28,10 @@ def get_device():
         return torch.device("cpu")
 
 def train(num_epochs=20, learning_rate=0.001, batch_size=64, seed=42):
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
 
     set_seed(seed)
     
-    mlflow.set_tracking_uri("http://mlflow:5000")
     mlflow.set_experiment("mnist-digit-captcha")    
     with mlflow.start_run():    
         device = get_device()
@@ -85,7 +86,13 @@ def train(num_epochs=20, learning_rate=0.001, batch_size=64, seed=42):
                 mlflow.log_artifact("tests/best_model.pth")
                 print(f"Best model saved and logged with val acc: {val_acc:.4f}")
             scheduler.step()
-        mlflow.pytorch.log_model(model, artifact_path="model", registered_model_name="HybridCNN")
+        client = MlflowClient()
+        run_id = mlflow.active_run().info.run_id
+        model_uri = f"runs:/{run_id}/model"
+        mv = client.create_model_version(name="HybridCNN", source=model_uri, run_id=run_id)
+        version = mv.version
+        client.set_model_version_tag(name="HybridCNN", version=version, key="timestamp", value=timestamp)
+        client.set_registered_model_alias(name="HybridCNN", alias=timestamp, version=version)
         mlflow.log_param("epochs", num_epochs)
         mlflow.log_param("optimizer", "Adam")
         mlflow.log_param("learning_rate", learning_rate)


### PR DESCRIPTION
자동화를 위해 크론탭 추가
별도 도커 컨테이너 실행
컨테이너 내에서 수동으로 .sh파일로 실행 가능

//도커 실행
docker-compose up --build -d 
//새로 만든 도커 컨테이너 내부에서 수동실행(자동으로는 매일 자정 실행)
docker exec -it mlflow-trainer bash
cd /app
bash auto_run/run_training.sh

하면 수동으로 작업 가능합니다.
num_epochs=20이 너무 오래걸려서 
num_epochs=1로 바꿔서 테스트해봐주시면 감사하겠습니다!

너무 오래걸려서 죄송합니다 ㅠㅠ